### PR TITLE
added education section

### DIFF
--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { motion } from "framer-motion"
+import { GraduationCap, MapPin, Award, BookOpen } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { educations } from "@/data/education"
+
+const fadeInUp = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 }
+}
+
+export default function EducationPage() {
+  return (
+    <div className="min-h-screen py-20 px-4 sm:px-6 lg:px-8">
+      <div className="container mx-auto max-w-6xl">
+        <motion.div
+          className="text-center mb-16"
+          initial="hidden"
+          animate="visible"
+          variants={fadeInUp}
+          transition={{ duration: 0.6 }}
+        >
+          <h1 className="text-4xl md:text-5xl font-bold mb-4 py-1 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+            Education
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            My academic journey and the knowledge that shaped my career
+          </p>
+        </motion.div>
+
+        <div className="space-y-8">
+          {educations.map((education, index) => (
+            <motion.div
+              key={index}
+              initial="hidden"
+              animate="visible"
+              variants={fadeInUp}
+              transition={{ duration: 0.6, delay: index * 0.2 }}
+            >
+              <Card className="overflow-hidden border-2 hover:border-primary/20 transition-all duration-300 hover:shadow-xl">
+                <CardHeader className="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-950/20 dark:to-purple-950/20">
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-start gap-4">
+                      <div className="p-2 bg-primary/10 rounded-lg">
+                        <GraduationCap className="w-6 h-6 text-primary" />
+                      </div>
+                      <div>
+                        <CardTitle className="text-xl md:text-2xl mb-2">
+                          {education.degree}
+                        </CardTitle>
+                        <CardDescription className="text-base font-medium text-primary">
+                          {education.institution}
+                        </CardDescription>
+                      </div>
+                    </div>
+                    {education.gpa && (
+                      <Badge variant="secondary" className="text-sm font-semibold">
+                        GPA: {education.gpa}
+                      </Badge>
+                    )}
+                  </div>
+                  
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground mt-4">
+                    <span>{education.duration}</span>
+                    <span>•</span>
+                    <div className="flex items-center gap-1">
+                      <MapPin className="w-4 h-4" />
+                      <span>{education.location}</span>
+                    </div>
+                  </div>
+                </CardHeader>
+                
+                <CardContent className="pt-6">
+                  <div className="space-y-6">
+                    {/* Description */}
+                    <div>
+                      <h4 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                        <BookOpen className="w-5 h-5 text-primary" />
+                        Overview
+                      </h4>
+                      <ul className="space-y-2">
+                        {education.description.map((desc, i) => (
+                          <li key={i} className="flex items-start gap-2">
+                            <span className="text-primary mt-1">•</span>
+                            <span className="text-muted-foreground">{desc}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    {/* Subjects */}
+                    <div>
+                      <h4 className="text-lg font-semibold mb-3">Key Subjects</h4>
+                      <div className="flex flex-wrap gap-2">
+                        {education.subjects.map((subject, i) => (
+                          <Badge key={i} variant="outline" className="text-sm">
+                            {subject}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* Achievements */}
+                    {education.achievements && education.achievements.length > 0 && (
+                      <div>
+                        <h4 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                          <Award className="w-5 h-5 text-primary" />
+                          Achievements
+                        </h4>
+                        <ul className="space-y-2">
+                          {education.achievements.map((achievement, i) => (
+                            <li key={i} className="flex items-start gap-2">
+                              <span className="text-primary mt-1">🏆</span>
+                              <span className="text-muted-foreground">{achievement}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -35,6 +35,7 @@ const NAV_ITEMS = [
   { name: "Home", href: "/" },
   { name: "About", href: "/about" },
   { name: "Projects", href: "/projects" },
+  { name: "Education", href: "/education" },
   { name: "Blog", href: "/blog" },
   { name: "Contact", href: "/contact" },
 ] as const

--- a/data/education.ts
+++ b/data/education.ts
@@ -1,0 +1,67 @@
+export interface EducationItem {
+  degree: string;
+  institution: string;
+  duration: string;
+  location: string;
+  gpa?: string;
+  description: string[];
+  subjects: string[];
+  achievements?: string[];
+}
+
+export const educations: EducationItem[] = [
+  {
+    degree: "Bachelor of Technology in Computer Science and Engineering",
+    institution: "University College of Engineering & Technology, Hazaribagh",
+    duration: "2021 – 2025",
+    location: "Hazaribagh, Jharkhand",
+    gpa: "8.5/10",
+    description: [
+      "Comprehensive study of computer science fundamentals including algorithms, data structures, and software engineering",
+      "Specialized coursework in machine learning, artificial intelligence, and web development",
+      "Active participation in coding competitions and technical projects"
+    ],
+    subjects: [
+      "Data Structures & Algorithms",
+      "Database Management Systems",
+      "Operating Systems",
+      "Computer Networks",
+      "Software Engineering",
+      "Machine Learning",
+      "Artificial Intelligence",
+      "Web Technologies",
+      "Object-Oriented Programming",
+      "Computer Architecture"
+    ],
+    achievements: [
+      "Dean's List for academic excellence",
+      "Top 10% in class ranking",
+      "Active member of coding club",
+      "Participated in multiple hackathons and coding competitions"
+    ]
+  },
+  {
+    degree: "Higher Secondary Education (12th Grade)",
+    institution: "Don Bosco School",
+    duration: "2019 – 2021",
+    location: "Hazaribagh, Jharkhand",
+    gpa: "85%",
+    description: [
+      "Completed higher secondary education with focus on Science stream",
+      "Strong foundation in Mathematics, Physics, and Chemistry",
+      "Developed analytical and problem-solving skills"
+    ],
+    subjects: [
+      "Mathematics",
+      "Physics",
+      "Chemistry",
+      "Computer Science",
+      "English"
+    ],
+    achievements: [
+      "Distinction in Mathematics and Computer Science",
+      "Active participant in science exhibitions",
+      "Member of school debate team"
+    ]
+  }
+];


### PR DESCRIPTION
This pull request adds a new Education section to the application, providing a detailed and visually appealing overview of academic history. The main changes include implementing the `EducationPage` component, creating a structured education data source, and updating navigation to include the new page.

**Education Page Implementation:**

* Added the `EducationPage` component in `app/education/page.tsx`, featuring animated cards for each education entry, including degree, institution, GPA, duration, location, overview, key subjects, and achievements.

**Data Structure:**

* Created the `EducationItem` interface and populated the `educations` array in `data/education.ts` with detailed information for each educational experience.

**Navigation Update:**

* Added the Education link to the navigation bar in `components/navigation.tsx` to make the new page accessible from the main site menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an Education page displaying academic history with animated cards: degree, institution, duration, location, optional GPA and achievements, plus overview and key subjects (as badges).
  * Polished visuals with gradient header, relevant icons, and subtle hover interactions.
  * Staggered fade-in animations enhance readability and engagement.
  * Added “Education” to the site navigation for quick access (desktop and mobile).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->